### PR TITLE
fix: support resources with only block attributes

### DIFF
--- a/lua/treesitter-terraform-doc/init.lua
+++ b/lua/treesitter-terraform-doc/init.lua
@@ -155,7 +155,7 @@ local get_block_info = function(node, bufnr)
           (body
             (attribute
                 (identifier) @argument_name
-            )
+            )?
           )
         )
     ]])


### PR DESCRIPTION
Some Terraform resources only have blocks as attributes. This is common for the Kubernetes provider, where most resources only have two blocks (spec and metadata). For instance:

```hcl
resource "kubernetes_namespace" "this" {
  metadata {
    name   = "example"
  }
}
```

In the absence of a non-block attribute, the treesitter query does not match the resource, and thus the `:OpenDoc` command fails with "Invalid resource targeted, try a 'resource' or 'data' block".

This MR fixes that.

Tested on my local setup, on a few examples, both with and without block attributes.