### PR TITLE
Add cloudflare to providers table

### DIFF
--- a/lua/treesitter-terraform-doc/init.lua
+++ b/lua/treesitter-terraform-doc/init.lua
@@ -39,6 +39,10 @@ M.providers = {
     {
         prefix = "newrelic",
         name = "newrelic"
+    },
+    {
+        prefix = "cloudflare",
+        name = "cloudflare"
     }
 }
 M.default_provider = "hashicorp"


### PR DESCRIPTION
In order to open the correct location for the cloudflare provider I added it to the provider lookup table.