### PR TITLE
fix: migrate to treesitter main branch

### DIFF
--- a/lua/treesitter-terraform-doc/init.lua
+++ b/lua/treesitter-terraform-doc/init.lua
@@ -211,7 +211,6 @@ local open_doc_from_cursor_position = function()
 	end
 
 	local source, provider, type, name, argument_name = get_block_info(node, bufnr)
-	print(source, provider, type, name, argument_name)
 	if provider == nil or name == nil then
 		return
 	end

--- a/lua/treesitter-terraform-doc/init.lua
+++ b/lua/treesitter-terraform-doc/init.lua
@@ -1,49 +1,47 @@
-local ts_util = require('nvim-treesitter.ts_utils')
-local q = require('vim.treesitter.query')
-local utils = require('treesitter-terraform-doc.utils')
+local utils = require("treesitter-terraform-doc.utils")
 
 local M = {}
 
 M.version = "0.3.0"
 M.config = {
-    -- The vim user command that will trigger the plugin.
-    command_name       = "OpenDoc",
+	-- The vim user command that will trigger the plugin.
+	command_name = "OpenDoc",
 
-    -- The command that will take the url as a parameter.
-    url_opener_command = "!open",
+	-- The command that will take the url as a parameter.
+	url_opener_command = "!open",
 
-    -- If true, the cursor will jump to the anchor in the documentation.
-    jump_anchor      = true,
+	-- If true, the cursor will jump to the anchor in the documentation.
+	jump_anchor = true,
 }
 M.block_type_url_mapping = {
-    resource = "resources",
-    data     = "data-sources"
+	resource = "resources",
+	data = "data-sources",
 }
 M.providers = {
-    {
-        prefix = "ibm",
-        name   = "IBM-Cloud",
-    },
-    {
-        prefix = "shell",
-        name   = "scottwinkler",
-    },
-    {
-        prefix = "fastly",
-        name   = "fastly",
-    },
-    {
-        prefix = "vcd",
-        name = "vmware"
-    },
-    {
-        prefix = "newrelic",
-        name = "newrelic"
-    },
-    {
-        prefix = "cloudflare",
-        name = "cloudflare"
-    }
+	{
+		prefix = "ibm",
+		name = "IBM-Cloud",
+	},
+	{
+		prefix = "shell",
+		name = "scottwinkler",
+	},
+	{
+		prefix = "fastly",
+		name = "fastly",
+	},
+	{
+		prefix = "vcd",
+		name = "vmware",
+	},
+	{
+		prefix = "newrelic",
+		name = "newrelic",
+	},
+	{
+		prefix = "cloudflare",
+		name = "cloudflare",
+	},
 }
 M.default_provider = "hashicorp"
 
@@ -53,20 +51,20 @@ M.default_provider = "hashicorp"
 -- @param current_node node The current used node.
 -- @return node?
 local find_uppest_parent = function(current_node)
-    local root = ts_util.get_root_for_node(current_node)
-    local parent = current_node:parent()
+	local root = current_node:tree():root()
+	local parent = current_node:parent()
 
-    if parent:parent() == nil then
-        print("No parent found")
-        return nil
-    end
+	if parent:parent() == nil then
+		print("No parent found")
+		return nil
+	end
 
-    while parent:parent() ~= root do
-        current_node = parent
-        parent = current_node:parent()
-    end
+	while parent:parent() ~= root do
+		current_node = parent
+		parent = current_node:parent()
+	end
 
-    return current_node
+	return current_node
 end
 
 ---
@@ -79,14 +77,14 @@ end
 ---@return          string  The second part of the string
 ---@nodiscard
 local split_at_first_occurence = function(s, char, exclude)
-    exclude = exclude or true
+	exclude = exclude or true
 
-    local index = string.find(s, char)
-    local first = string.sub(s, 1, index - 1)
+	local index = string.find(s, char)
+	local first = string.sub(s, 1, index - 1)
 
-    local second_index = exclude and index + 1 or index
-    local second = string.sub(s, second_index, -1)
-    return first, second
+	local second_index = exclude and index + 1 or index
+	local second = string.sub(s, second_index, -1)
+	return first, second
 end
 
 ---
@@ -98,25 +96,25 @@ end
 ---@return       table   The dictionary of all match and their text value.
 ---@return       integer The length of the dictionary.
 local get_matches_from_node = function(query, node, bufnr, current_line)
-    local dict = {}
-    local dict_length = 0
+	local dict = {}
+	local dict_length = 0
 
-    for id, capture, _ in query:iter_captures(node, bufnr) do
-        local name = query.captures[id]
-        if not dict[name] then              -- Prevent inserting the same thing twice in the array.
-            if name == "argument_name" then -- If the argument is the name of one of the field return it.
-                local a = capture:range()
-                if M.config.jump_anchor and current_line == a + 1 then
-                    dict_length = dict_length + 1
-                    dict[name] = vim.treesitter.get_node_text(capture, bufnr)
-                end
-            else
-                dict_length = dict_length + 1
-                dict[name] = vim.treesitter.get_node_text(capture, bufnr)
-            end
-        end
-    end
-    return dict, dict_length
+	for id, capture, _ in query:iter_captures(node, bufnr) do
+		local name = query.captures[id]
+		if not dict[name] then -- Prevent inserting the same thing twice in the array.
+			if name == "argument_name" then -- If the argument is the name of one of the field return it.
+				local a = capture:range()
+				if M.config.jump_anchor and current_line == a + 1 then
+					dict_length = dict_length + 1
+					dict[name] = vim.treesitter.get_node_text(capture, bufnr)
+				end
+			else
+				dict_length = dict_length + 1
+				dict[name] = vim.treesitter.get_node_text(capture, bufnr)
+			end
+		end
+	end
+	return dict, dict_length
 end
 
 ---
@@ -126,13 +124,13 @@ end
 -- @return         string The provider source.
 -- @nodiscard
 local find_provider_source = function(provider)
-    for _, v in ipairs(M.providers) do
-        if v.prefix == provider then
-            return v.name
-        end
-    end
+	for _, v in ipairs(M.providers) do
+		if v.prefix == provider then
+			return v.name
+		end
+	end
 
-    return M.default_provider
+	return M.default_provider
 end
 
 ---
@@ -147,7 +145,9 @@ end
 ---@return      string? The argument name.
 ---@nodiscard
 local get_block_info = function(node, bufnr)
-    local query = vim.treesitter.query.parse('hcl', [[
+	local query = vim.treesitter.query.parse(
+		"hcl",
+		[[
         (block
           (identifier) @block_type (#match? @block_type "resource|data")
           (string_lit
@@ -162,51 +162,75 @@ local get_block_info = function(node, bufnr)
             )?
           )
         )
-    ]])
+    ]]
+	)
 
-    local cursor = vim.api.nvim_win_get_cursor(0)
-    local current_line = cursor[1]
-    local dict, dict_length = get_matches_from_node(query, node, bufnr, current_line)
+	local cursor = vim.api.nvim_win_get_cursor(0)
+	local current_line = cursor[1]
+	local dict, dict_length = get_matches_from_node(query, node, bufnr, current_line)
 
-    -- Checks if all captures have matched
-    if dict_length ~= 3 and dict_length ~= 4 then
-        print("Invalid resource targeted, try a 'resource' or 'data' block")
-        return nil, nil
-    end
+	-- Checks if all captures have matched
+	if dict_length ~= 3 and dict_length ~= 4 then
+		print("Invalid resource targeted, try a 'resource' or 'data' block")
+		return nil, nil
+	end
 
-    local provider, name = split_at_first_occurence(dict["resource"], "_")
-    local type = M.block_type_url_mapping[dict["block_type"]]
+	local provider, name = split_at_first_occurence(dict["resource"], "_")
+	local type = M.block_type_url_mapping[dict["block_type"]]
 
-    local source = find_provider_source(provider)
+	local source = find_provider_source(provider)
 
-    return source, provider, type, name, dict["argument_name"]
+	return source, provider, type, name, dict["argument_name"]
 end
 
 ---
 --- Open the terraform documentation from the current cursor position.
 ---
 local open_doc_from_cursor_position = function()
-    local bufnr = vim.api.nvim_get_current_buf()
-    local cursor = ts_util.get_node_at_cursor()
-    local node = find_uppest_parent(cursor)
-    if node == nil then
-        return
-    end
+	local bufnr = vim.api.nvim_get_current_buf()
+	local parser = vim.treesitter.get_parser(0, "terraform")
+	if parser == nil then
+		print("No parser found for the current buffer, please ensure you are starting treesitter properly.")
+		return
+	end
 
-    local source, provider, type, name, argument_name = get_block_info(node, bufnr)
-    if provider == nil or name == nil then
-        return
-    end
+	local cursor_node
+	local ok = pcall(require, "nvim-treesitter.ts_utils")
+	if ok then
+		-- Old version of nvim-treesitter we are setting cursor using the old way
+		local ts_utils = require("nvim-treesitter.ts_utils")
+		cursor_node = ts_utils.get_node_at_cursor()
+	else
+		-- Using the new way to get the cursor node
+		cursor_node = vim.treesitter.get_node()
+	end
 
-    local url = 'https://registry.terraform.io/providers/' .. source .. '/' ..
-        provider .. '/latest/docs/' .. type .. '/' .. name
+	local node = find_uppest_parent(cursor_node)
+	if node == nil then
+		return
+	end
 
-    if M.config.jump_anchor and argument_name then
-        url = url .. "\\\\#" .. argument_name
-    end
+	local source, provider, type, name, argument_name = get_block_info(node, bufnr)
+	print(source, provider, type, name, argument_name)
+	if provider == nil or name == nil then
+		return
+	end
 
-    local cmd = 'silent exec "' .. M.config.url_opener_command .. ' \'' .. url .. '\'"'
-    vim.cmd(cmd)
+	local url = "https://registry.terraform.io/providers/"
+		.. source
+		.. "/"
+		.. provider
+		.. "/latest/docs/"
+		.. type
+		.. "/"
+		.. name
+
+	if M.config.jump_anchor and argument_name then
+		url = url .. "\\\\#" .. argument_name .. "-1" -- The '-1' is to match the id generated by terraform doc.
+	end
+
+	local cmd = 'silent exec "' .. M.config.url_opener_command .. " '" .. url .. "'\""
+	vim.cmd(cmd)
 end
 
 ---
@@ -215,13 +239,9 @@ end
 ---
 --- @param config table The configuration table.
 M.setup = function(config)
-    M.config = table.merge(M.config, config)
+	M.config = utils.merge(M.config, config)
 
-    vim.api.nvim_create_user_command(
-        M.config.command_name,
-        open_doc_from_cursor_position,
-        { nargs = 0 }
-    )
+	vim.api.nvim_create_user_command(M.config.command_name, open_doc_from_cursor_position, { nargs = 0 })
 end
 
 return M

--- a/lua/treesitter-terraform-doc/utils.lua
+++ b/lua/treesitter-terraform-doc/utils.lua
@@ -1,10 +1,10 @@
 local M = {}
 
-function table.merge(t1, t2)
+function M.merge(t1, t2)
   for k, v in pairs(t2) do
     if type(v) == "table" then
       if type(t1[k] or false) == "table" then
-        table.merge(t1[k] or {}, t2[k] or {})
+        M.merge(t1[k] or {}, t2[k] or {})
       else
         t1[k] = v
       end


### PR DESCRIPTION
This pull request:
- migrate to stylua
- update treesitter API to use the new version (rewrite on main branch)
- should keep backward compatibility for users running on the master branch
- add `-i` after the HTML anchors to handle properly the new format of the terraform anchors